### PR TITLE
[TASK] Streamline naming of select options translation keys

### DIFF
--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -67,7 +67,7 @@ class Select extends AbstractMultiValueFormField {
 		} elseif (TRUE === is_string($this->items)) {
 			$itemNames = GeneralUtility::trimExplode(',', $this->items);
 			foreach ($itemNames as $itemName) {
-				$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', 'fields.' . $this->name . '.option.' . $itemName);
+				$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', 'fields.' . $this->name . '.options.' . $itemName);
 				if (0 === strpos($resolvedLabel, 'LLL:') ) {
 					$resolvedLabel = $itemName;
 				}

--- a/Classes/Form/Field/Select.php
+++ b/Classes/Form/Field/Select.php
@@ -67,7 +67,7 @@ class Select extends AbstractMultiValueFormField {
 		} elseif (TRUE === is_string($this->items)) {
 			$itemNames = GeneralUtility::trimExplode(',', $this->items);
 			foreach ($itemNames as $itemName) {
-				$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', $this->name . '.option.' . $itemName);
+				$resolvedLabel = $this->resolveLocalLanguageValueOfLabel('', 'fields.' . $this->name . '.option.' . $itemName);
 				if (0 === strpos($resolvedLabel, 'LLL:') ) {
 					$resolvedLabel = $itemName;
 				}


### PR DESCRIPTION
1. use "options." instead of "option." to be in line with "fields." and "columns."
2. prepend "fields." before the field name